### PR TITLE
fix(options): need to restart if back in work hours

### DIFF
--- a/index.js
+++ b/index.js
@@ -61,7 +61,7 @@ module.exports = {
     }
 }
 
-function pollAndNotify(){
+function pollAndNotify() {
     var now = new Date();
     var hours = now.getHours();
     var day = now.getDay();
@@ -72,12 +72,16 @@ function pollAndNotify(){
         else{
             // Only execute the poller when it's during working hours
             if (hours >= workStart && hours < workEnd && day != 0 && day != 6) {
-                    Object.keys(pendings).map(function(a){
-                        Slack.notify(a, pendings[a], function(err, done){});
-                    });             
+                Object.keys(pendings).map(function(a){
+                    Slack.notify(a, pendings[a], function(err, done){});
+                });
+                
                 setTimeout(pollAndNotify, interval * 60 * 60 * 1000);
             } else {
                 console.log('All work and no play makes Jack a dull boy.');
+
+                // Polls every 15 min to check if we're back in work hours
+                setTimeout(pollAndNotify, interval * 60 * 7500);
             }
         }
     });


### PR DESCRIPTION
### Story
Noticed a bug with Snowball - if it was running continuously and fell outside of work hours for the first time after it was initialized, it would never restart the poller and notifier properly. This adds a second poller to check if the bot has come back into work hours, and if so, it should start notifications again.

### Testing
We'll run snowball with this fix locally. It should notify people continuously for a couple days, only in work hours.