### PR TITLE
feat(options): don't remind if changes were requested

### DIFF
--- a/lib/github.js
+++ b/lib/github.js
@@ -148,7 +148,7 @@ github.prototype = {
                             return false;
 
 
-                        if(b.state == "APPROVED")
+                        if(b.state == "APPROVED" || b.state == "CHANGES_REQUESTED")
                             return true;
 
                         if(b.submitted_at < pullRequest.updated_at)


### PR DESCRIPTION
### Story
Reviewers shouldn't get reminders when they've already done a review and asked for changes to be made to the PR.

### Testing
Already working locally. Cory confirmed that he was not getting reminders anymore for a PR he had been tagged to review by Vasil for which he'd asked for changes. 